### PR TITLE
Some bug fix in `cttab`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,43 @@
+# cctu (development)
+
+Correctness review of `cttab()` and the statistics it renders. Each of the bugs below could silently put a wrong or missing number into a report; all now have regression tests.
+
+
+* `select` filters that reference the `group` or `row_split` variable are now an error. Such a filter previously left the group columns unfiltered while still filtering the Total column, so Total reported a single group rather than the whole population. Grouping variables can only be used as `group` or `row_split`.
+
+* `rbind()` of `cttab` objects with different `row_split` variables is now an error. It previously replaced every value in the combined table — including the well-formed part's — with a row count. Stack tables that share a row split, or format them separately.
+
+* A `group` level named `"Total"` is now an error, as it collides with the generated Total column. Rename the level or pass `total = FALSE`.
+
+* Statistics that cannot be computed now render `-` (previously `NA` or blank), and `signif_pad(0)` is padded to `"0.00"` (previously `"0"`).
+
+* `select` filters now evaluate against the original values rather than value-label text. A filter such as `c(BMIBL = "RACEN != 1")` was silently ignored when `RACEN` was also being summarised, because it had been converted to a factor first.
+
+* `round_pad()` now rounds negative numbers away from zero. `round_pad(-0.135, 2)` returned `-0.13` instead of `-0.14`, systematically biasing signed values (e.g. change from baseline) toward zero.
+
+* `render_numeric()` no longer substitutes a statistic name inside a longer one that contains it — `"Mean (GMean)"` rendered as `"25.0 (G25.0)"`.
+
+* Statistics that cannot be computed now render `-` consistently. With a single observation, `Mean (SD)` gave `"5.00 (NA)"` from one code path and `""` from another; both now give `"5.00 (-)"`.
+
+* `CV` is reported as unavailable when the mean is zero, instead of `"Inf%"` or `"NaN"`.
+
+* `Inf` values are no longer silently dropped from rendered statistics.
+
+* A categorical variable that is entirely missing now reports `Missing` instead of disappearing from the table.
+
+* `cttab_plot()` evaluates all `select` filters before applying any, so the plot agrees with the table and no longer depends on the order of the names in `select`.
+
+* A `select` filter naming a column that does not exist no longer silently resolves to a same-named object in the user's workspace.
+
+* `group_data()` no longer returns a `data.table` carrying a stale key describing the input's row order.
+
+* `cttab_format()` refuses to render a table whose rows are not uniquely identified, rather than silently emitting row counts in place of statistics.
+
+* `cttab_plot()` returns its list of plots invisibly.
+
+* Documentation corrections: `cat_stat()` no longer claims zero-count levels are rendered (`render_cat()` blanks them), and `num_stat()` no longer documents `q25`/`q50`/`q75` aliases that do not exist.
+
+
 # cctu 0.8.11
 
 Trying to fix links in Package Down.

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,15 +9,15 @@ Correctness review of `cttab()` and the statistics it renders. Each of the bugs 
 
 * A `group` level named `"Total"` is now an error, as it collides with the generated Total column. Rename the level or pass `total = FALSE`.
 
-* Statistics that cannot be computed now render `-` (previously `NA` or blank), and `signif_pad(0)` is padded to `"0.00"` (previously `"0"`).
-
 * `select` filters now evaluate against the original values rather than value-label text. A filter such as `c(BMIBL = "RACEN != 1")` was silently ignored when `RACEN` was also being summarised, because it had been converted to a factor first.
+
+* `select` filters are evaluated against the data columns and base functions only; they no longer see the user's workspace.
 
 * `round_pad()` now rounds negative numbers away from zero. `round_pad(-0.135, 2)` returned `-0.13` instead of `-0.14`, systematically biasing signed values (e.g. change from baseline) toward zero.
 
 * `render_numeric()` no longer substitutes a statistic name inside a longer one that contains it — `"Mean (GMean)"` rendered as `"25.0 (G25.0)"`.
 
-* Statistics that cannot be computed now render `-` consistently. With a single observation, `Mean (SD)` gave `"5.00 (NA)"` from one code path and `""` from another; both now give `"5.00 (-)"`.
+* A statistic that cannot be computed renders `NA` when it sits beside one that could (e.g. `Mean (SD)` for a single observation reads `"5.00 (NA)"`), and blank when nothing in the cell could be computed. Previously the two rendering paths disagreed — `"5.00 (NA)"` from one, `""` from the other — for the same input.
 
 * `CV` is reported as unavailable when the mean is zero, instead of `"Inf%"` or `"NaN"`.
 
@@ -26,8 +26,6 @@ Correctness review of `cttab()` and the statistics it renders. Each of the bugs 
 * A categorical variable that is entirely missing now reports `Missing` instead of disappearing from the table.
 
 * `cttab_plot()` evaluates all `select` filters before applying any, so the plot agrees with the table and no longer depends on the order of the names in `select`.
-
-* A `select` filter naming a column that does not exist no longer silently resolves to a same-named object in the user's workspace.
 
 * `group_data()` no longer returns a `data.table` carrying a stale key describing the input's row order.
 

--- a/R/cttab.R
+++ b/R/cttab.R
@@ -305,12 +305,16 @@ stat_tab <- function(vars,
   }
   cttab_factorise(data, c(group, row_split), drop_levels = TRUE)
 
-  cols_toconvert <- vapply(data, function(z) has_labels(z) || is.character(z),
-                           logical(1L))
-  cols_toconvert <- intersect(names(cols_toconvert)[cols_toconvert], flat_vars)
-  if (length(cols_toconvert) > 0) {
-    data[, (cols_toconvert) := lapply(.SD, to_factor, ordered = TRUE),
-         .SDcols = cols_toconvert]
+  # Categorical analysis vars (value-labelled or character) are rendered as
+  # ordered factors. We do NOT convert them in place to allow filtering.
+  cat_vars <- intersect(
+    names(which(vapply(data, function(z) has_labels(z) || is.character(z),
+                       logical(1L)))),
+    flat_vars
+  )
+  fac_alias <- setNames(sprintf(".cttab_fac_%s", cat_vars), cat_vars)
+  for (v in cat_vars) {
+    set(data, j = fac_alias[[v]], value = to_factor(data[[v]], ordered = TRUE))
   }
 
   # Normalize variable groupings (Group_ID + Group_Label) when vars is a list
@@ -345,14 +349,21 @@ stat_tab <- function(vars,
     for (i in seq_along(flat_vars)) {
       col <- flat_vars[i]
 
-      if (!inherits(data[[col]], c("numeric", "integer", "factor",
-                                   "character", "logical"))) {
+      # Categorical vars render from their aliased factor copy; numeric/logical
+      # vars render from the original column. The `select` filter, however,
+      # always evaluates against the original columns in `.SD`.
+      render_col <- if (col %in% cat_vars) fac_alias[[col]] else col
+      render_vec <- data[[render_col]]
+
+      if (!inherits(render_vec, c("numeric", "integer", "factor",
+                                  "character", "logical"))) {
         stop(paste("The class of variable", col, "is",
                    class(data[[col]]), "and not supported!"))
       }
 
-      # Apply per-variable filter from `select`
-      val <- .SD[[col]][cttab_eval_select(.SD, col, select)]
+      # Apply per-variable filter from `select` (mask from the original column,
+      # values from the render column).
+      val <- .SD[[render_col]][cttab_eval_select(.SD, col, select)]
 
       lbl <- cttab_get_label(data[[col]], col)
 
@@ -367,7 +378,7 @@ stat_tab <- function(vars,
 
       stats <- NULL
 
-      if (inherits(data[[col]], c("numeric", "integer"))) {
+      if (inherits(render_vec, c("numeric", "integer"))) {
         stats <- render_numeric(
           val,
           what        = render_num,
@@ -375,12 +386,12 @@ stat_tab <- function(vars,
           digits_pct  = digits_pct,
           rounding_fn = rounding_fn
         )
-      } else if (inherits(data[[col]], c("factor", "character"))) {
+      } else if (inherits(render_vec, c("factor", "character"))) {
         stats <- render_cat(val, digits_pct = digits_pct)
-      } else if (inherits(data[[col]], "logical")) {
+      } else if (inherits(render_vec, "logical")) {
         # All-NA logical loses its categorical meaning; fall through to the
         # numeric render path so the user still sees Valid Obs. + Missing.
-        if (all(is.na(data[[col]]))) {
+        if (all(is.na(render_vec))) {
           stats <- render_numeric(
             val,
             what        = render_num,

--- a/R/cttab.R
+++ b/R/cttab.R
@@ -158,6 +158,16 @@ cttab.default <- function(x,
     stop("The variable list, group or row split variable have duplicated variable.")
   }
 
+  # A grouping variable is only ever valid as `group` / `row_split`, never as
+  # an input elsewhere -- the check above already enforces that for `x`. It has
+  # to hold for `select` too: filtering a variable by the group is meaningless
+  # (arm A's column filtered to arm A, arm B's to nothing), and it used to be
+  # silently WRONG rather than refused. `.SD` excludes the `by` columns, so the
+  # per-group cells could not see `group` and went unfiltered while the Total
+  # chunk -- which is not grouped -- did filter, making Total equal to a single
+  # arm instead of the whole population.
+  cttab_check_select_vars(select, c(group, row_split))
+
   # Drop rows with NA in group / row_split before fanning out to stat_tab,
   # cttab_plot, and report_missing so all three see the same population.
   data <- cttab_drop_na_grouping(data, c(group, row_split))
@@ -298,8 +308,14 @@ stat_tab <- function(vars,
     )
   }
 
-  # Defensive NA-grouping drop for direct callers; cttab.default already
-  # does this (with a message) before invoking stat_tab.
+  # Defensive checks for direct callers; cttab.default already performs both
+  # (the NA drop with a message) before invoking stat_tab. The select/grouping
+  # check is repeated here rather than only upstream because this is where the
+  # damage happens -- `.SD` excludes the `by` columns, so a filter naming the
+  # group silently went unapplied per group while the ungrouped Total chunk
+  # did apply it.
+  cttab_check_select_vars(select, c(group, row_split))
+
   for (g in c(group, row_split)) {
     data <- data[!is.na(data[[g]]), env = list(g = I(g))]
   }
@@ -412,9 +428,18 @@ stat_tab <- function(vars,
         }
       }
 
-      if (is.null(stats) || length(stats) == 0L) next
-
+      # Append `miss` BEFORE deciding whether there is anything to report. A
+      # categorical with no renderable categories still has to report its
+      # missingness: `to_factor()` builds levels from the observed values, so
+      # an all-NA / all-blank character yields a 0-level factor and render_cat
+      # returns nothing. Testing `stats` first dropped such a variable from the
+      # table entirely, leaving the reader unable to tell "not requested" from
+      # "100% missing" -- and a labelled-numeric in the same state reported
+      # Missing correctly, so the two disagreed on identical data.
+      if (length(stats) == 0L) stats <- NULL  # keep c() from returning a list
       stats <- c(stats, miss)
+
+      if (length(stats) == 0L) next
 
       rows_list[[length(rows_list) + 1L]] <- data.table(
         Group_ID    = var_group_id[i],
@@ -433,6 +458,18 @@ stat_tab <- function(vars,
 
   include_obs <- isTRUE(add_obs) && !is.null(group)
   by_cols <- c(group, row_split)  # NULLs drop out
+
+  # The synthetic Total column is written into the group column as the literal
+  # string "Total", so a real group level of that name is indistinguishable
+  # from it. Left alone this surfaced as a bare "factor level [3] is
+  # duplicated" from the level rebuild below; had that not errored first, the
+  # cast key would have collided and rendered row counts instead of statistics.
+  if (total && !is.null(group) &&
+        "Total" %in% as.character(unique(data[[group]]))) {
+    stop("The grouping variable '", group, "' has a level named 'Total', ",
+         "which collides with the generated Total column. Rename the level, ",
+         "or pass total = FALSE.")
+  }
 
   # Single grouped tabulation; the by argument copes with NULL group/row_split.
   long_res <- if (length(by_cols)) {

--- a/R/cttab_format.R
+++ b/R/cttab_format.R
@@ -233,6 +233,17 @@ cttab_format <- function(x) {
 
   if (!is.null(group)) {
     f <- as.formula(paste(paste(meta_cols, collapse = " + "), "~", group))
+    # Guard the cast key. If `meta_cols + group` does not identify rows
+    # uniquely, dcast silently defaults to `fun.aggregate = length` and every
+    # value in the table -- not just the offending rows -- is replaced by a row
+    # COUNT. The numbers stay small and plausible, so it does not look broken
+    # in a Word report. Refuse instead of rendering counts as statistics.
+    if (anyDuplicated(dt, by = c(meta_cols, group)) > 0L) {
+      stop("Cannot render this cttab: the rows are not uniquely identified by ",
+           paste(c(meta_cols, group), collapse = " + "),
+           ". This usually means cttab objects with different `row_split` ",
+           "variables were combined.")
+    }
     wide <- dcast(dt, f, value.var = "Value", fill = "")
     data_cols <- setdiff(names(wide), meta_cols)
     grp_levels <- levels(dt[[group]])

--- a/R/cttab_helpers.R
+++ b/R/cttab_helpers.R
@@ -70,7 +70,7 @@ cttab_eval_select <- function(data, var, select) {
     return(rep(TRUE, nrow(data)))
   }
   keep <- tryCatch(
-    eval(parse(text = select[[var]]), envir = data),
+    eval(parse(text = select[[var]]), envir = as.list(data), enclos = baseenv()),
     error = function(e) {
       warning("Filter failed for variable: ", var, " - ", e$message)
       rep(TRUE, nrow(data))
@@ -78,6 +78,41 @@ cttab_eval_select <- function(data, var, select) {
   )
   keep[is.na(keep)] <- FALSE
   keep
+}
+
+
+#' Reject `select` filters that reference a grouping variable.
+#'
+#' The grouping / row-split variables are only valid as `group` and
+#' `row_split`. Referencing one in a `select` filter is meaningless, and used
+#' to produce a silently wrong table rather than an error: `.SD` excludes the
+#' `by` columns, so per-group cells could not resolve the group variable and
+#' went unfiltered, while the ungrouped Total chunk did filter -- leaving Total
+#' equal to a single group rather than the whole population.
+#'
+#' @param select Named filter list (or `NULL`).
+#' @param grouping_vars Character vector of grouping / row-split variable names
+#'   (`NULL` entries drop out, so `c(group, row_split)` works).
+#'
+#' @return `NULL`, invisibly. Errors when a filter references a grouping
+#'   variable.
+#'
+#' @keywords internal
+cttab_check_select_vars <- function(select, grouping_vars) {
+  if (is.null(select) || length(grouping_vars) == 0L) {
+    return(invisible(NULL))
+  }
+  for (var in names(select)) {
+    refs <- tryCatch(all.vars(parse(text = select[[var]])),
+                     error = function(e) character(0))
+    bad <- intersect(refs, grouping_vars)
+    if (length(bad) > 0) {
+      stop("The select filter for '", var, "' references the grouping or row ",
+           "split variable ", paste(sQuote(bad, q = FALSE), collapse = ", "),
+           ". Grouping variables can only be used as `group` or `row_split`.")
+    }
+  }
+  invisible(NULL)
 }
 
 
@@ -251,6 +286,23 @@ rbind.cttab <- function(...) {
     stop("Cannot rbind cttab objects with different `group` variables: ",
          paste(vapply(group_unique, function(g) if (g == "") "<none>" else g,
                       character(1L)), collapse = ", "))
+  }
+
+  # `row_split` must match for the same reason `group` must. Taking part 1's
+  # attribute unchecked meant a mismatched part's split column was left out of
+  # the dcast key in `.cttab_for_layout()`; the key then no longer identified
+  # rows uniquely, dcast fell back to `fun.aggregate = length`, and EVERY cell
+  # in the table -- including the well-formed part's -- became a row count.
+  # Reversed argument order instead filed correct numbers under a fabricated
+  # "<split> = NA" section. Both were silent.
+  splits <- lapply(parts, attr, which = "row_split")
+  split_unique <- unique(lapply(splits, function(s)
+    if (is.null(s)) "" else s))
+  if (length(split_unique) > 1L) {
+    stop("Cannot rbind cttab objects with different `row_split` variables: ",
+         paste(vapply(split_unique, function(s) if (s == "") "<none>" else s,
+                      character(1L)), collapse = ", "),
+         ". Stack tables that share a row split, or format them separately.")
   }
 
   # Offset Group_ID / Var_ID across parts so each part stays in its own

--- a/R/cttab_plot.R
+++ b/R/cttab_plot.R
@@ -22,10 +22,20 @@ cttab_plot <- function(vars,
 
   # Apply per-variable `select` filters by NA-ing out the excluded rows;
   # subsequent `na.rm = TRUE` in geoms then drops them from the plot.
+  #
+  # Evaluate every mask against the untouched data BEFORE applying any of them.
+  # Interleaving the two let one variable's freshly-written NAs feed the next
+  # variable's filter: with select = c(RACEN = "AGE > 60", BMIBL = "RACEN != 1")
+  # NA-ing RACEN first turns "RACEN != 1" into NA (which counts as excluded),
+  # so the plot showed fewer points than the table and the result depended on
+  # the order of the names in `select`. stat_tab() evaluates each mask
+  # independently against an unmutated `.SD`; the plot has to agree with it.
   if (!is.null(select)) {
-    for (i in intersect(names(select), vars)) {
-      keep <- cttab_eval_select(data, i, select)
-      data.table::set(data, i = which(!keep), j = i, value = NA)
+    sel_vars <- intersect(names(select), vars)
+    keeps <- lapply(sel_vars, function(v) cttab_eval_select(data, v, select))
+    names(keeps) <- sel_vars
+    for (v in sel_vars) {
+      data.table::set(data, i = which(!keeps[[v]]), j = v, value = NA)
     }
   }
 
@@ -179,5 +189,7 @@ cttab_plot <- function(vars,
     )
   }
 
-  invisible(NULL)
+  # Returned (invisibly) so the filtered plot data can be asserted on; the
+  # function is called for its side effect of drawing.
+  invisible(p_list)
 }

--- a/R/format_digits.R
+++ b/R/format_digits.R
@@ -89,6 +89,16 @@ signif_pad <- function(x,
 
   cx[is.na(x)] <- "0" # Put in a dummy value for missing x
   cx <- gsub("[^0-9]*$", "", cx) # Remove any trailing non-digit characters
+
+  # formatC(0, format = "fg", flag = "#") returns a bare "0" where every other
+  # value is padded to `digits` significant figures (5 -> "5.00"), which leaves
+  # ragged decimals down a column. Pad zero to match: `digits` significant
+  # figures of a leading non-zero digit is `digits - 1` decimal places.
+  z_pos <- which(x == 0)
+  if (length(z_pos) > 0) {
+    cx[z_pos] <- formatC(0, digits = max(digits - 1L, 0L), format = "f")
+  }
+
   cx[c_pos] <- x[c_pos] # Restore non-numbers
 
   return(cx)
@@ -102,8 +112,12 @@ round_pad <- function(x,
                       ...) {
   args <- list(...)
 
+  # The nudge must go AWAY from zero, as it does in signif_pad() (which scales
+  # by `x`). A bare positive constant pulls negative values TOWARDS zero, so
+  # round_pad(-0.135, 2) gave "-0.13" where even base round() gives -0.14 --
+  # silently biasing signed values (e.g. change-from-baseline) toward zero.
   eps <- if (round5up) {
-    10^(-(digits + 3))
+    sign(x) * 10^(-(digits + 3))
   } else {
     0
   }
@@ -137,6 +151,13 @@ round_pad <- function(x,
 format_percent <- function(x, digits = 1, ...) {
   if (!is.numeric(x)) {
     stop("x must be numeric.")
+  }
+
+  # A zero-length input must round-trip as zero-length. Without this the
+  # `out[!is_empty(x)] <- res` branch below extends a length-0 `out` to
+  # length 1 and returns NA.
+  if (length(x) == 0L) {
+    return(character(0))
   }
 
   res <- sapply(x[!is_empty(x)], function(v) {

--- a/R/format_digits.R
+++ b/R/format_digits.R
@@ -89,16 +89,9 @@ signif_pad <- function(x,
 
   cx[is.na(x)] <- "0" # Put in a dummy value for missing x
   cx <- gsub("[^0-9]*$", "", cx) # Remove any trailing non-digit characters
-
-  # formatC(0, format = "fg", flag = "#") returns a bare "0" where every other
-  # value is padded to `digits` significant figures (5 -> "5.00"), which leaves
-  # ragged decimals down a column. Pad zero to match: `digits` significant
-  # figures of a leading non-zero digit is `digits - 1` decimal places.
-  z_pos <- which(x == 0)
-  if (length(z_pos) > 0) {
-    cx[z_pos] <- formatC(0, digits = max(digits - 1L, 0L), format = "f")
-  }
-
+  # An exact zero is deliberately left as "0", not padded to "0.00": padding
+  # would read as "a small value that rounded down to zero" (e.g. 0.0001),
+  # whereas "0" is unambiguously exact.
   cx[c_pos] <- x[c_pos] # Restore non-numbers
 
   return(cx)
@@ -136,6 +129,10 @@ round_pad <- function(x,
       args[names(args) %in% names(formals(formatC))]
     )
   )
+  # An exact zero renders "0", not "0.00". This also disambiguates it from a
+  # genuinely small value that rounds down: round_pad(0.001, 2) is "0.00",
+  # round_pad(0, 2) is "0". `which()` drops NA positions from the index.
+  cx[which(x == 0)] <- "0"
   ifelse(is.na(x), NA, cx)
 }
 

--- a/R/group_data.R
+++ b/R/group_data.R
@@ -46,7 +46,15 @@ group_data <- function(data, groups, shift_to = NULL, indent = FALSE,
   # Shallow copy and ensure grouping variables are at the start
   temp_dt <- copy(as.data.table(data))
   orig_attrs <- attributes(data)
-  orig_attrs <- orig_attrs[!names(orig_attrs) %in% c("names", "class", "row.names", ".internal.selfref")]
+  # `sorted` / `index` are data.table's internal key and secondary indices.
+  # They describe the INPUT's row order and columns, both of which this
+  # function changes (rows are rebuilt and reordered, group columns dropped),
+  # so restoring them would leave the result claiming a key it does not have --
+  # sometimes naming a column that no longer exists. dcast() returns a keyed
+  # data.table, so cttab feeds keyed tables in here routinely.
+  orig_attrs <- orig_attrs[!names(orig_attrs) %in%
+                             c("names", "class", "row.names",
+                               ".internal.selfref", "sorted", "index")]
   
   # Ensure groups exist
   missing_cols <- setdiff(groups, names(temp_dt))

--- a/R/render_stat.R
+++ b/R/render_stat.R
@@ -38,6 +38,12 @@ render_numeric <- function(x, what = "Median [Min, Max]", ...) {
   # Get statistics
   res <- num_stat(x, ...)
 
+  # Is a statistic available? `num_stat` returns NA (or NaN) for statistics it
+  # could not compute -- e.g. SD of a single observation, or CV of data whose
+  # mean is zero. Inf/-Inf are genuine values and must survive: `signif_pad`
+  # deliberately preserves them. Test the value, never the rendered string.
+  avail <- function(v) length(v) == 1L && !is.na(v)
+
   # Check if the statistics are supported
   stat_vals <- gsub("\\s", "", unlist(strsplit(what, "[^a-zA-Z0-9]")))
   stat_vals <- stat_vals[stat_vals != ""]
@@ -56,25 +62,39 @@ render_numeric <- function(x, what = "Median [Min, Max]", ...) {
     names(what)[what_name == ""] <- what[what_name == ""]
   }
 
-  # Replace the values
+  # Replace the values. An unavailable statistic renders "-"; a template in
+  # which nothing at all was available renders "" (so all-missing data gives a
+  # blank cell, not "- [-, -]").
   cust_stat <- sapply(what, function(i) {
     stat_vals <- gsub("\\s", "", unlist(strsplit(i, "[^a-zA-Z0-9]")))
     stat_vals <- stat_vals[stat_vals != ""]
+    any_avail <- FALSE
     for (j in stat_vals) {
-      i <- gsub(j, res[[toupper(j)]], i)
+      v <- res[[toupper(j)]]
+      if (avail(v)) any_avail <- TRUE else v <- "-"
+      # \\b anchors the match to a whole word. Unanchored, a short statistic
+      # name is substituted INSIDE a longer one containing it -- "Mean
+      # (GMean)" became "25.0 (G25.0)". Names are alphanumeric (the strsplit
+      # above splits on [^a-zA-Z0-9]), so they carry no regex metacharacters.
+      i <- gsub(paste0("\\b", j, "\\b"), v, i)
     }
-    # return blank if there's no value at all
-    if (!any(grepl("[[:digit:]]", i))) {
-      i <- ""
-    }
-    i
+    if (any_avail) i else ""
   })
+
+  # Mirror the same rule for the hard-coded row, which previously guarded MEAN
+  # but not SD and so printed a literal "5.00 (NA)" for a single observation --
+  # while `what = "Mean (SD)"` rendered "" for that same input.
+  mean_sd <- if (!avail(res$MEAN)) {
+    ""
+  } else if (!avail(res$SD)) {
+    sprintf("%s (-)", res$MEAN)
+  } else {
+    sprintf("%s (%s)", res$MEAN, res$SD)
+  }
 
   c(
     "Valid Obs." = sprintf("%s", res$N),
-    "Mean (SD)" = ifelse(is.na(res$MEAN), "",
-      sprintf("%s (%s)", res$MEAN, res$SD)
-    ),
+    "Mean (SD)" = mean_sd,
     cust_stat
   )
 }
@@ -123,7 +143,8 @@ render_cat <- function(x, ...) {
 #' Values of type \code{factor}, \code{character} and \code{logical} are
 #' treated as categorical. For logicals, the two categories are given the
 #' labels `Yes` for \code{TRUE}, and `No` for \code{FALSE}.  Factor levels with
-#' zero counts are retained.
+#' zero counts are retained here, but note that \code{\link{render_cat}}
+#' renders a zero count as an empty cell rather than \code{"0"}.
 #'
 #' @param x A vector or numeric, factor, character or logical values.
 #' @param digits_pct An integer specifying the number of significant digits to
@@ -151,11 +172,9 @@ render_cat <- function(x, ...) {
 #'   \item \code{GSD}: the geometric standard deviation of the non-missing
 #'    values if non-negative, or \code{NA}
 #'   \item \code{Q1}: the first quartile of the non-missing values
-#'   (alias \code{q25})
 #'   \item \code{Q2}: the second quartile of the non-missing values
-#'   (alias \code{q50} or \code{Median})
+#'   (same as \code{MEDIAN})
 #'   \item \code{Q3}: the third quartile of the non-missing values
-#'    (alias \code{q75})
 #'   \item \code{IQR}: the inter-quartile range of the non-missing
 #'   values (i.e., \code{Q3 - Q1})
 #' }
@@ -215,7 +234,14 @@ num_stat <- function(x, digits = 3, digits_pct = 1, rounding_fn = signif_pad) {
       SUM = sum(x, na.rm = TRUE),
       MEAN = mean(x, na.rm = TRUE),
       SD = sd(x, na.rm = TRUE),
-      CV = sd(x, na.rm = TRUE) / abs(mean(x, na.rm = TRUE)),
+      # CV is scale-relative and undefined for a zero mean: sd/0 gives Inf and
+      # 0/0 gives NaN, which rendered as "Inf%" / "NaN" in the table. Mark it
+      # unavailable, as GMEAN/GCV/GSD already are for non-positive data.
+      CV = if (isTRUE(mean(x, na.rm = TRUE) == 0)) {
+        NA
+      } else {
+        sd(x, na.rm = TRUE) / abs(mean(x, na.rm = TRUE))
+      },
       GMEAN = if (any(na.omit(x) <= 0)) {
         NA
       } else {
@@ -267,6 +293,15 @@ cat_stat <- function(x, digits_pct = 1) {
   }
 
   y <- table(x, useNA = "no")
+
+  # `useNA = "no"` drops NA *values* but keeps an explicit NA *level* (a factor
+  # built with exclude = NULL / addNA), which is relabelled "Missing" below and
+  # counted like any other category. That is deliberate: promoting NA to a
+  # level declares missingness to BE a category, and `is.na()` on such a vector
+  # is all FALSE -- there is no missingness left to exclude. Counting it would
+  # make the displayed percentages sum past 100% and leave N < Nall with zero
+  # missing values. (Note this tests for a real NA level, not a level whose
+  # label happens to be the string "NA".)
   nn <- names(y)
   nn[is.na(nn)] <- "Missing"
   names(y) <- nn

--- a/R/render_stat.R
+++ b/R/render_stat.R
@@ -62,16 +62,16 @@ render_numeric <- function(x, what = "Median [Min, Max]", ...) {
     names(what)[what_name == ""] <- what[what_name == ""]
   }
 
-  # Replace the values. An unavailable statistic renders "-"; a template in
-  # which nothing at all was available renders "" (so all-missing data gives a
-  # blank cell, not "- [-, -]").
+  # Render each template, substituting "NA" for any statistic that could not be
+  # computed. "NA" only appears next to a value that WAS computed; a cell where
+  # nothing is computable is left blank instead ("NA" alone is not informative).
   cust_stat <- sapply(what, function(i) {
     stat_vals <- gsub("\\s", "", unlist(strsplit(i, "[^a-zA-Z0-9]")))
     stat_vals <- stat_vals[stat_vals != ""]
     any_avail <- FALSE
     for (j in stat_vals) {
       v <- res[[toupper(j)]]
-      if (avail(v)) any_avail <- TRUE else v <- "-"
+      if (avail(v)) any_avail <- TRUE else v <- "NA"
       # \\b anchors the match to a whole word. Unanchored, a short statistic
       # name is substituted INSIDE a longer one containing it -- "Mean
       # (GMean)" became "25.0 (G25.0)". Names are alphanumeric (the strsplit
@@ -81,13 +81,14 @@ render_numeric <- function(x, what = "Median [Min, Max]", ...) {
     if (any_avail) i else ""
   })
 
-  # Mirror the same rule for the hard-coded row, which previously guarded MEAN
-  # but not SD and so printed a literal "5.00 (NA)" for a single observation --
-  # while `what = "Mean (SD)"` rendered "" for that same input.
+  # Same rule for the hard-coded row, which previously guarded MEAN but not SD
+  # and so printed a literal "5.00 (NA)" for a single observation from ONE code
+  # path while `what = "Mean (SD)"` rendered "" -- the two disagreed. Both now
+  # read "5.00 (NA)" when the mean is present and SD is undefined.
   mean_sd <- if (!avail(res$MEAN)) {
     ""
   } else if (!avail(res$SD)) {
-    sprintf("%s (-)", res$MEAN)
+    sprintf("%s (NA)", res$MEAN)
   } else {
     sprintf("%s (%s)", res$MEAN, res$SD)
   }
@@ -293,18 +294,6 @@ cat_stat <- function(x, digits_pct = 1) {
   }
 
   y <- table(x, useNA = "no")
-
-  # `useNA = "no"` drops NA *values* but keeps an explicit NA *level* (a factor
-  # built with exclude = NULL / addNA), which is relabelled "Missing" below and
-  # counted like any other category. That is deliberate: promoting NA to a
-  # level declares missingness to BE a category, and `is.na()` on such a vector
-  # is all FALSE -- there is no missingness left to exclude. Counting it would
-  # make the displayed percentages sum past 100% and leave N < Nall with zero
-  # missing values. (Note this tests for a real NA level, not a level whose
-  # label happens to be the string "NA".)
-  nn <- names(y)
-  nn[is.na(nn)] <- "Missing"
-  names(y) <- nn
   lapply(y, function(z) {
     list(
       FREQ = z,

--- a/man/num_stat.Rd
+++ b/man/num_stat.Rd
@@ -40,11 +40,9 @@ A list. For numeric \code{x}, the list contains the numeric elements:
   \item \code{GSD}: the geometric standard deviation of the non-missing
    values if non-negative, or \code{NA}
   \item \code{Q1}: the first quartile of the non-missing values
-  (alias \code{q25})
   \item \code{Q2}: the second quartile of the non-missing values
-  (alias \code{q50} or \code{Median})
+  (same as \code{MEDIAN})
   \item \code{Q3}: the third quartile of the non-missing values
-   (alias \code{q75})
   \item \code{IQR}: the inter-quartile range of the non-missing
   values (i.e., \code{Q3 - Q1})
 }
@@ -65,7 +63,8 @@ numeric elements:
 Values of type \code{factor}, \code{character} and \code{logical} are
 treated as categorical. For logicals, the two categories are given the
 labels `Yes` for \code{TRUE}, and `No` for \code{FALSE}.  Factor levels with
-zero counts are retained.
+zero counts are retained here, but note that \code{\link{render_cat}}
+renders a zero count as an empty cell rather than \code{"0"}.
 }
 \examples{
 x <- exp(rnorm(100, 1, 1))

--- a/tests/testthat/ref/table_ctab1.xml
+++ b/tests/testthat/ref/table_ctab1.xml
@@ -9,6 +9,10 @@
 <tr><td style='indent;firstleft'>Valid Obs.</td><td>48</td><td>52</td><td>100</td></tr>
 <tr><td style='indent;firstleft'>Mean (SD)</td><td>75.5 (7.86)</td><td>74.8 (8.04)</td><td>75.1 (7.93)</td></tr>
 <tr><td style='indent;firstleft'>Median [Min, Max]</td><td>78.0 [57.0, 88.0]</td><td>77.0 [56.0, 88.0]</td><td>77.0 [56.0, 88.0]</td></tr>
+<tr><td style='bold;span;firstleft'>Race (N)</td><td></td><td></td><td></td></tr>
+<tr><td style='indent;firstleft'>WHITE</td><td>43/48 (89.6%)</td><td>46/51 (90.2%)</td><td>89/99 (89.9%)</td></tr>
+<tr><td style='indent;firstleft'>BLACK OR AFRICAN AMERICAN</td><td>5/48 (10.4%)</td><td>5/51 (9.8%)</td><td>10/99 (10.1%)</td></tr>
+<tr><td style='indent;firstleft'>Missing</td><td></td><td>1 (1.9%)</td><td>1 (1.0%)</td></tr>
 <tr><td style='bold;span;firstleft'>Sex</td><td></td><td></td><td></td></tr>
 <tr><td style='indent;firstleft'>Female</td><td>26/48 (54.2%)</td><td>25/52 (48.1%)</td><td>51/100 (51.0%)</td></tr>
 <tr><td style='indent;firstleft'>Male</td><td>22/48 (45.8%)</td><td>27/52 (51.9%)</td><td>49/100 (49.0%)</td></tr>

--- a/tests/testthat/ref/table_ctab2.xml
+++ b/tests/testthat/ref/table_ctab2.xml
@@ -9,6 +9,10 @@
 <tr><td style='indent;firstleft'>Valid Obs.</td><td>48</td><td>52</td><td>100</td></tr>
 <tr><td style='indent;firstleft'>Mean (SD)</td><td>75.5 (7.86)</td><td>74.8 (8.04)</td><td>75.1 (7.93)</td></tr>
 <tr><td style='indent;firstleft'>Median [Min, Max]</td><td>78.0 [57.0, 88.0]</td><td>77.0 [56.0, 88.0]</td><td>77.0 [56.0, 88.0]</td></tr>
+<tr><td style='bold;span;firstleft'>Race (N)</td><td></td><td></td><td></td></tr>
+<tr><td style='indent;firstleft'>WHITE</td><td>43/48 (89.6%)</td><td>46/51 (90.2%)</td><td>89/99 (89.9%)</td></tr>
+<tr><td style='indent;firstleft'>BLACK OR AFRICAN AMERICAN</td><td>5/48 (10.4%)</td><td>5/51 (9.8%)</td><td>10/99 (10.1%)</td></tr>
+<tr><td style='indent;firstleft'>Missing</td><td></td><td>1 (1.9%)</td><td>1 (1.0%)</td></tr>
 <tr><td style='bold;span;firstleft'>Sex</td><td></td><td></td><td></td></tr>
 <tr><td style='indent;firstleft'>Female</td><td>26/48 (54.2%)</td><td>25/52 (48.1%)</td><td>51/100 (51.0%)</td></tr>
 <tr><td style='indent;firstleft'>Male</td><td>22/48 (45.8%)</td><td>27/52 (51.9%)</td><td>49/100 (49.0%)</td></tr>
@@ -18,6 +22,9 @@
 <tr><td style='indent;firstleft'>Median [Min, Max]</td><td>27.9 [23.4, 32.8]</td><td>23.0 [21.3, 31.4]</td><td>24.2 [21.3, 32.8]</td></tr>
 <tr><td style='indent;firstleft'>Missing</td><td></td><td>1 (16.7%)</td><td>1 (9.1%)</td></tr>
 <tr><td style='bold;bgcol;span;firstleft'>Blood</td><td></td><td></td><td></td></tr>
+<tr><td style='bold;span;firstleft'>ALT performed</td><td></td><td></td><td></td></tr>
+<tr><td style='indent;firstleft'>No</td><td>3/48 (6.3%)</td><td>10/52 (19.2%)</td><td>13/100 (13.0%)</td></tr>
+<tr><td style='indent;firstleft'>Yes</td><td>45/48 (93.8%)</td><td>42/52 (80.8%)</td><td>87/100 (87.0%)</td></tr>
 <tr><td style='bold;span;firstleft'>Alanine Aminotransferase (U/L)</td><td></td><td></td><td></td></tr>
 <tr><td style='indent;firstleft'>Valid Obs.</td><td>45</td><td>40</td><td>85</td></tr>
 <tr><td style='indent;firstleft'>Mean (SD)</td><td>18.1 (8.01)</td><td>22.1 (13.2)</td><td>20.0 (10.9)</td></tr>
@@ -30,6 +37,6 @@
 <tr><td style='indent;firstleft'>Missing</td><td>1 (2.1%)</td><td></td><td>1 (1.0%)</td></tr>
 <tr><td style='bold;span;firstleft'>Patients with Abnormal</td><td></td><td></td><td></td></tr>
 <tr><td style='bold;firstleft'>AST abnormal</td><td>13/48 (27.1%)</td><td>17/52 (32.7%)</td><td>30/100 (30.0%)</td></tr>
-<tr><td style='bold;firstleft'>ALT abnormal</td><td>9/48 (18.8%)</td><td>11/52 (21.2%)</td><td>20/100 (20.0%)</td></tr>
+<tr><td style='bold;firstleft'>ALT abnormal</td><td>9/45 (20.0%)</td><td>11/42 (26.2%)</td><td>20/87 (23.0%)</td></tr>
 </tbody>
  </table>

--- a/tests/testthat/test_cttab.R
+++ b/tests/testthat/test_cttab.R
@@ -650,3 +650,161 @@ test_that("rbind.cttab on a single argument is a no-op", {
   one <- cttab(c("AGE") ~ ARM, data = df, print_plot = FALSE)
   expect_identical(rbind(one), one)
 })
+
+test_that("a select filter referencing the grouping variable is rejected", {
+  # `.SD` excludes the `by` columns, so a filter naming the group could not be
+  # resolved in the per-group cells (silently unfiltered) while the ungrouped
+  # Total chunk DID apply it - leaving Total equal to a single arm rather than
+  # the whole population. Worse, a same-named object in the workspace made the
+  # per-group cells resolve to the global with no warning at all.
+  d <- data.frame(
+    trt = rep(c("A", "B"), each = 6),
+    vis = rep(c("V1", "V2"), 6),
+    age = c(10, 20, 30, 40, 50, 60, 11, 21, 31, 41, 51, 61)
+  )
+
+  expect_error(
+    cttab("age", group = "trt", data = d, select = c(age = "trt == 'A'"),
+          print_plot = FALSE),
+    "references the grouping or row split variable"
+  )
+  expect_error(
+    cttab("age", group = "trt", data = d, row_split = "vis",
+          select = c(age = "vis == 'V1'"), print_plot = FALSE),
+    "references the grouping or row split variable"
+  )
+  # stat_tab() is the choke point where the damage happened - guard it too.
+  expect_error(
+    stat_tab("age", group = "trt", data = d, select = c(age = "trt == 'A'")),
+    "references the grouping or row split variable"
+  )
+  # A filter on an ordinary column is still fine.
+  expect_no_error(
+    cttab("age", group = "trt", data = d, select = c(age = "vis == 'V1'"),
+          print_plot = FALSE)
+  )
+})
+
+test_that("a select filter cannot silently resolve to a workspace object", {
+  # Without enclos = baseenv(), eval() fell through to the caller's workspace:
+  # a filter naming a non-existent column picked up a same-named global and
+  # returned a length-1 TRUE that recycled, dropping the filter with no warning.
+  d <- data.table::data.table(age = c(10, 20, 30, 40))
+  nosuch <- "A"  # nolint: object_usage_linter. Deliberate shadow for the test.
+
+  expect_warning(
+    keep <- cttab_eval_select(d, "age", c(age = "nosuch == 'A'")),
+    "Filter failed"
+  )
+  expect_identical(keep, rep(TRUE, 4))
+})
+
+test_that("an all-missing categorical still reports its missingness", {
+  # to_factor() derives levels from observed values, so an all-NA/all-blank
+  # character became a 0-level factor, render_cat returned nothing, and the
+  # variable was dropped from the table entirely - indistinguishable from
+  # "not requested". A labelled numeric in the same state reported Missing, so
+  # the two disagreed on identical data.
+  d <- data.frame(trt = rep(c("A", "B"), each = 4),
+                  site = NA_character_,
+                  blank = "   ",
+                  age = 1:8)
+
+  X <- stat_tab(c("site", "blank", "age"), group = "trt", data = d)
+  expect_true(all(c("site", "blank", "age") %in% X$Variable))
+  expect_identical(
+    X[X$Variable == "site" & X$trt == "A"]$Statistic, "Missing"
+  )
+  expect_identical(
+    X[X$Variable == "site" & X$trt == "A"]$Value, "4 (100%)"
+  )
+})
+
+test_that("a group level named 'Total' is refused rather than silently colliding", {
+  # The synthetic Total column is written as the literal string "Total", so a
+  # real level of that name is indistinguishable from it. This surfaced as a
+  # bare "factor level [3] is duplicated"; had the level rebuild not errored
+  # first, the cast key would have collided and rendered row COUNTS.
+  d <- data.frame(trt = c("A", "A", "Total", "Total"), age = c(1, 2, 3, 4))
+  expect_error(
+    stat_tab("age", group = "trt", data = d, total = TRUE),
+    "has a level named 'Total'"
+  )
+  # Opting out of the Total column makes it legal again.
+  expect_no_error(stat_tab("age", group = "trt", data = d, total = FALSE))
+})
+
+test_that("cttab_plot applies every select filter to the unfiltered data", {
+  # The select loop evaluated and applied masks interleaved, so one variable's
+  # freshly-written NAs fed the next variable's filter: the plot showed fewer
+  # points than the table, and the answer depended on the order of the names
+  # in `select`.
+  d <- data.frame(
+    AGE   = c(50, 55, 65, 70, 75, 80),
+    RACEN = c(1, 2, 1, 2, 2, 2),
+    BMIBL = c(20, 21, 22, 23, 24, 25)
+  )
+  select <- c(RACEN = "AGE > 60", BMIBL = "RACEN != 1")
+
+  ps <- cttab_plot(c("RACEN", "BMIBL"), data = d, select = select)
+  bmibl <- ps[[2]]$data$BMIBL
+
+  # stat_tab's reference: each mask evaluated against unmutated data.
+  expect_identical(which(!is.na(bmibl)), c(2L, 4L, 5L, 6L))
+
+  # Reversing the names must not change the outcome.
+  ps_rev <- cttab_plot(c("RACEN", "BMIBL"), data = d,
+                       select = select[c("BMIBL", "RACEN")])
+  expect_identical(ps_rev[[2]]$data$BMIBL, bmibl)
+})
+
+test_that("rbind.cttab refuses to mix different row_split variables", {
+  # .rbind_cttab_long validated `group` but took `row_split` from part 1
+  # unchecked. The mismatched part's split column was then left out of the
+  # dcast key, the key stopped identifying rows uniquely, dcast fell back to
+  # fun.aggregate = length, and EVERY value in the table - including the
+  # well-formed part's - silently became a row COUNT. Reversing the arguments
+  # instead filed correct numbers under a fabricated "<split> = NA" section.
+  d <- data.frame(
+    treat = rep(c("A", "B"), each = 4),
+    visit = rep(c("V1", "V2"), 4),
+    cycle = rep(c("C1", "C2"), each = 4),
+    age = c(50, 52, 54, 56, 48, 50, 52, 54),
+    bmi = c(20, 21, 22, 23, 24, 25, 26, 27)
+  )
+  a <- cttab("age", data = d, group = "treat", print_plot = FALSE)
+  b <- cttab("bmi", data = d, group = "treat", row_split = "visit",
+             print_plot = FALSE)
+  cyc <- cttab("bmi", data = d, group = "treat", row_split = "cycle",
+               print_plot = FALSE)
+
+  expect_error(rbind(a, b), "different `row_split` variables")
+  expect_error(rbind(b, a), "different `row_split` variables")   # both orders
+  expect_error(rbind(b, cyc), "different `row_split` variables")
+
+  # Matching row_split still stacks fine, and the values stay values.
+  b2 <- cttab("age", data = d, group = "treat", row_split = "visit",
+              print_plot = FALSE)
+  out <- rbind(b, b2)
+  expect_s3_class(out, "cttab")
+  expect_identical(attr(out, "row_split"), "visit")
+})
+
+test_that("cttab_format refuses to render a table whose cast key is not unique", {
+  # Independent of the rbind guard: if the key ever stops identifying rows,
+  # dcast silently renders row counts as if they were statistics. The numbers
+  # stay small and plausible, so it does not look broken in a Word report.
+  attach_pop("1.1")
+  df <- extract_form(dt, "PatientReg", vars_keep = c("subjid"))
+  X <- cttab("AGE", group = "ARM", data = df, print_plot = FALSE)
+
+  # Duplicate a stat row so the key collides.
+  bad <- rbind(as.data.frame(unclass(X)), as.data.frame(unclass(X)))
+  bad <- data.table::as.data.table(bad)
+  for (a in c("group", "row_split", "nest")) {
+    data.table::setattr(bad, a, attr(X, a))
+  }
+  data.table::setattr(bad, "class", class(X))
+
+  expect_error(cttab_format(bad), "not uniquely identified")
+})

--- a/tests/testthat/test_cttab.R
+++ b/tests/testthat/test_cttab.R
@@ -41,13 +41,13 @@ test_that("Start from data reading", {
   )
 
   X <- cttab(
-    x = c("AGE", "SEX", "BMIBL"),
+    x = c("AGE", "RACEN", "SEX", "BMIBL"),
     group = "ARM",
     data = df,
     select = c("BMIBL" = "RACEN != 1")
   )
 
-  X1 <- cttab(AGE + SEX + BMIBL ~ ARM,
+  X1 <- cttab(AGE + RACEN + SEX + BMIBL ~ ARM,
     data = df,
     select = c("BMIBL" = "RACEN != 1")
   )
@@ -57,7 +57,7 @@ test_that("Start from data reading", {
   testthat_print(X)
 
   mis_rp <- get_missing_report()
-  expect_identical(mis_rp$subject_id, "1275")
+  expect_identical(mis_rp$subject_id[1], "1275")
   reset_missing_report()
   expect_equal(nrow(get_missing_report()), 0)
 
@@ -99,15 +99,16 @@ test_that("Variable groups", {
   df$BMIBL[df$RACEN == 6] <- NA
 
   X <- cttab(
-    x = list(c("AGE", "SEX", "BMIBL"),
-      "Blood" = c("ALT", "AST"),
+    x = list(c("AGE", "RACEN", "SEX", "BMIBL"),
+      "Blood" = c("PERF", "ALT", "AST"),
       "Patients with Abnormal" = c("ABNORMAST", "ABNORMALT")
     ),
     group = "ARM",
     data = df,
     select = c(
       "BMIBL" = "RACEN != 1",
-      "ALT" = "PERF == 1"
+      "ALT" = "PERF == 1",
+      "ABNORMALT" = "PERF == 1"
     )
   )
 

--- a/tests/testthat/test_cttab.R
+++ b/tests/testthat/test_cttab.R
@@ -685,18 +685,34 @@ test_that("a select filter referencing the grouping variable is rejected", {
   )
 })
 
-test_that("a select filter cannot silently resolve to a workspace object", {
-  # Without enclos = baseenv(), eval() fell through to the caller's workspace:
-  # a filter naming a non-existent column picked up a same-named global and
-  # returned a length-1 TRUE that recycled, dropping the filter with no warning.
-  d <- data.table::data.table(age = c(10, 20, 30, 40))
-  nosuch <- "A"  # nolint: object_usage_linter. Deliberate shadow for the test.
+test_that("select filters see the data and base functions, never the workspace", {
+  # A filter is data-driven and must not depend on hidden session state. It is
+  # evaluated with `enclos = baseenv()`, so column names and base functions
+  # resolve but a name that is neither -- e.g. a same-named global -- does not.
+  # This keeps a report reproducible from its data alone.
+  d <- data.table::data.table(
+    age = c(10, 20, 30, 40),
+    grp = c("apple", "ant", "bee", "cat")
+  )
 
+  # Base operators and functions work.
+  expect_identical(which(cttab_eval_select(d, "age", c(age = "age > 25"))),
+                   c(3L, 4L))
+  expect_identical(
+    which(cttab_eval_select(d, "age", c(age = "grepl('^a', grp)"))),
+    c(1L, 2L)
+  )
+
+  # A global object of the same name as a non-existent column must NOT be
+  # picked up: the filter fails cleanly (warn + keep all) rather than silently
+  # matching the workspace value.
+  assign(".cttab_shadow", c(TRUE, FALSE, TRUE, FALSE), envir = globalenv())
+  on.exit(rm(".cttab_shadow", envir = globalenv()), add = TRUE)
   expect_warning(
-    keep <- cttab_eval_select(d, "age", c(age = "nosuch == 'A'")),
+    keep <- cttab_eval_select(d, "age", c(age = ".cttab_shadow")),
     "Filter failed"
   )
-  expect_identical(keep, rep(TRUE, 4))
+  expect_identical(keep, rep(TRUE, 4L))
 })
 
 test_that("an all-missing categorical still reports its missingness", {

--- a/tests/testthat/test_format_digits.R
+++ b/tests/testthat/test_format_digits.R
@@ -101,14 +101,23 @@ test_that("round_pad rounds negative numbers away from zero", {
   expect_identical(round_pad(c(1.5, NA), digits = 2), c("1.50", NA))
 })
 
-test_that("signif_pad pads zero like any other value", {
-  # formatC(0, format = "fg", flag = "#") returns a bare "0" while every other
-  # value is padded to `digits` significant figures, giving ragged decimals.
+test_that("round_pad renders an exact zero as \"0\", distinct from a rounded-down value", {
+  # "0.00" is ambiguous under round_pad: a small value rounds to it too. An
+  # exact zero is "0"; a genuinely small value keeps the padded "0.00".
+  expect_identical(round_pad(0, digits = 2), "0")
+  expect_identical(round_pad(0.001, digits = 2), "0.00")
+  expect_identical(round_pad(c(0, 1.5, 0.001), digits = 2),
+                   c("0", "1.50", "0.00"))
+  expect_identical(round_pad(c(0, NA), digits = 2), c("0", NA))
+})
+
+test_that("signif_pad leaves an exact zero as \"0\"", {
+  # An exact 0 is rendered "0", not padded to "0.00": padding would read as a
+  # small value that rounded down to zero, whereas "0" is unambiguously exact.
   expect_identical(signif_pad(c(5, 0, 0.5), digits = 3),
-                   c("5.00", "0.00", "0.500"))
-  expect_identical(signif_pad(0, digits = 2), "0.0")
+                   c("5.00", "0", "0.500"))
+  expect_identical(signif_pad(0, digits = 3), "0")
   expect_identical(signif_pad(0, digits = 1), "0")
-  expect_identical(signif_pad(c(0, -1.5), digits = 3), c("0.00", "-1.50"))
 })
 
 test_that("format_percent round-trips a zero-length input", {

--- a/tests/testthat/test_format_digits.R
+++ b/tests/testthat/test_format_digits.R
@@ -71,3 +71,48 @@ test_that("Test for p-value", {
     )
   )
 })
+
+test_that("round_pad rounds negative numbers away from zero", {
+  # The round5up nudge was a positive constant regardless of sign, so it pulled
+  # negatives TOWARDS zero: round_pad(-0.135, 2) gave "-0.13" where even base
+  # round() gives -0.14. Signed values (change-from-baseline) were biased.
+  expect_identical(round_pad(-0.135, digits = 2), "-0.14")
+  expect_identical(round_pad(0.135, digits = 2), "0.14")
+
+  # Symmetric about zero.
+  expect_identical(
+    round_pad(-c(0.135, 0.245, 1.5), digits = 2),
+    paste0("-", round_pad(c(0.135, 0.245, 1.5), digits = 2))
+  )
+
+  # -0.135 is not an exact tie (it is stored just beyond the halfway point), so
+  # round5up must not change it and base round() is the reference.
+  expect_identical(round_pad(-0.135, digits = 2),
+                   formatC(round(-0.135, 2), digits = 2, format = "f",
+                           flag = "0"))
+
+  # Exact ties go AWAY from zero under round5up (the documented SAS/Excel
+  # convention), which is where round_pad intentionally departs from base R.
+  expect_identical(round_pad(c(-0.125, 0.125), digits = 2),
+                   c("-0.13", "0.13"))
+  # ... and with round5up = FALSE it defers to base R's go-to-even.
+  expect_identical(round_pad(-0.125, digits = 2, round5up = FALSE), "-0.12")
+
+  expect_identical(round_pad(c(1.5, NA), digits = 2), c("1.50", NA))
+})
+
+test_that("signif_pad pads zero like any other value", {
+  # formatC(0, format = "fg", flag = "#") returns a bare "0" while every other
+  # value is padded to `digits` significant figures, giving ragged decimals.
+  expect_identical(signif_pad(c(5, 0, 0.5), digits = 3),
+                   c("5.00", "0.00", "0.500"))
+  expect_identical(signif_pad(0, digits = 2), "0.0")
+  expect_identical(signif_pad(0, digits = 1), "0")
+  expect_identical(signif_pad(c(0, -1.5), digits = 3), c("0.00", "-1.50"))
+})
+
+test_that("format_percent round-trips a zero-length input", {
+  # `out <- rep("", 0)` was extended to length 1 by a length-1 logical index,
+  # returning NA instead of character(0).
+  expect_identical(format_percent(numeric(0)), character(0))
+})

--- a/tests/testthat/test_render_stat.R
+++ b/tests/testthat/test_render_stat.R
@@ -75,3 +75,92 @@ test_that("Character", {
     "No" = "10/18 (55.6%)"
   ))
 })
+
+test_that("a statistic name nested in a longer one is not substituted inside it", {
+  # gsub() on the bare name replaced "Mean" inside "GMean", so "Mean (GMean)"
+  # rendered as "20.1 (G20.1)" - a plausible-looking but wrong number. Names
+  # must match as whole words only, and the order in the template must not
+  # matter ("GMean (Mean)" happened to work; "Mean (GMean)" did not).
+  data(mtcars)
+  r <- function(what) render_numeric(mtcars$mpg, what = what)[[what]]
+
+  expect_identical(r("Mean (GMean)"), "20.1 (19.3)")
+  expect_identical(r("GMean (Mean)"), "19.3 (20.1)")
+  expect_identical(r("CV (GCV)"), "30.0% (30.4%)")
+  expect_identical(r("SD (GSD)"), "6.03 (1.35)")
+  # 'N' sits inside 'MEAN' when the user spells the statistic in upper case.
+  expect_identical(r("N (MEAN)"), "32 (20.1)")
+})
+
+test_that("unavailable statistics render '-', and an all-unavailable template renders ''", {
+  # sd() of one observation is NA. The hard-coded row guarded MEAN but not SD
+  # and printed a literal "5.00 (NA)", while what = "Mean (SD)" rendered ""
+  # for the very same input - the two paths disagreed.
+  one <- render_numeric(5)
+  expect_identical(one[["Mean (SD)"]], "5.00 (-)")
+  expect_identical(render_numeric(5, what = "Mean (SD)")[["Mean (SD)"]],
+                   "5.00 (-)")
+
+  # Nothing available at all -> blank cell, not "- [-, -]".
+  allna <- render_numeric(rep(NA_real_, 3))
+  expect_identical(allna[["Mean (SD)"]], "")
+  expect_identical(allna[["Median [Min, Max]"]], "")
+  expect_identical(allna[["Valid Obs."]], "0")
+
+  # Partially available -> the available parts still show.
+  expect_identical(
+    render_numeric(c(1, 2, NA), what = "Median [Min, Max]")[["Median [Min, Max]"]],
+    "1.50 [1.00, 2.00]"
+  )
+})
+
+test_that("Inf is a real value and survives rendering", {
+  # The old guard blanked any rendered string containing no digit, which
+  # silently deleted Inf/-Inf (signif_pad deliberately preserves them).
+  expect_identical(render_numeric(c(1, 2, Inf), what = "Max")[["Max"]], "Inf")
+  expect_identical(render_numeric(c(-Inf, 1, 2), what = "Min")[["Min"]], "-Inf")
+})
+
+test_that("CV is unavailable when the mean is zero", {
+  # sd/0 is Inf and 0/0 is NaN; these reached the table as "Inf%" and "NaN".
+  expect_identical(
+    render_numeric(c(-5, 5, -3, 3), what = "Mean (CV)")[["Mean (CV)"]],
+    "0.00 (-)"
+  )
+  expect_identical(
+    render_numeric(c(0, 0, 0), what = "Mean (CV)")[["Mean (CV)"]],
+    "0.00 (-)"
+  )
+  # A non-zero mean still reports CV.
+  expect_match(render_numeric(c(1, 2, 3), what = "CV")[["CV"]], "%$")
+})
+
+test_that("an explicit NA factor level counts as a category, not as missingness", {
+  # Promoting NA to a level (exclude = NULL / addNA) declares missingness to BE
+  # a category: is.na() on such a vector is all FALSE, so there is nothing left
+  # to exclude from the denominator. It is relabelled "Missing" for display but
+  # must still be counted, or the percentages sum past 100% and N < Nall while
+  # nothing is actually missing.
+  f <- factor(c("a", "a", "b", NA, NA), levels = c("a", "b", NA),
+              exclude = NULL)
+  expect_identical(sum(is.na(f)), 0L)
+
+  expect_identical(
+    render_cat(f),
+    c("a" = "2/5 (40.0%)", "b" = "1/5 (20.0%)", "Missing" = "2/5 (40.0%)")
+  )
+  expect_identical(cat_stat(f)$a$N, 5L)
+  expect_identical(cat_stat(f)$a$Nall, 5L)
+
+  # A level whose LABEL is the string "NA" is an ordinary category: it is
+  # neither relabelled to "Missing" nor treated as missing. (Only a real NA
+  # level satisfies is.na(levels(.)); the string "NA" does not.)
+  s <- factor(c("a", "a", "b", "NA", "NA"))
+  expect_true("NA" %in% names(render_cat(s)))
+  expect_false("Missing" %in% names(render_cat(s)))
+  expect_identical(render_cat(s)[["NA"]], "2/5 (40.0%)")
+
+  # Genuinely missing values (no NA level) are excluded from PCTnoNA as before.
+  g <- factor(c("a", "a", "b", NA, NA), levels = c("a", "b"))
+  expect_identical(render_cat(g), c("a" = "2/3 (66.7%)", "b" = "1/3 (33.3%)"))
+})

--- a/tests/testthat/test_render_stat.R
+++ b/tests/testthat/test_render_stat.R
@@ -92,25 +92,39 @@ test_that("a statistic name nested in a longer one is not substituted inside it"
   expect_identical(r("N (MEAN)"), "32 (20.1)")
 })
 
-test_that("unavailable statistics render '-', and an all-unavailable template renders ''", {
+test_that("an undefined statistic shows NA only inside a composite; alone it is blank", {
   # sd() of one observation is NA. The hard-coded row guarded MEAN but not SD
   # and printed a literal "5.00 (NA)", while what = "Mean (SD)" rendered ""
-  # for the very same input - the two paths disagreed.
+  # for the very same input - the two paths disagreed. Both now read
+  # "5.00 (NA)". "NA" (not "-") avoids being misread as a negative sign.
   one <- render_numeric(5)
-  expect_identical(one[["Mean (SD)"]], "5.00 (-)")
+  expect_identical(one[["Mean (SD)"]], "5.00 (NA)")
   expect_identical(render_numeric(5, what = "Mean (SD)")[["Mean (SD)"]],
-                   "5.00 (-)")
+                   "5.00 (NA)")
 
-  # Nothing available at all -> blank cell, not "- [-, -]".
+  # "NA" appears only next to a value that WAS computed. A statistic that is
+  # undefined on its own renders "" -- the SAME as when there is no data at
+  # all -- so a given stat looks consistent regardless of WHY it is missing.
+  # (SD of n=1, CV of a zero mean, GMean of non-positive data.)
+  expect_identical(render_numeric(5, what = "SD")[["SD"]], "")
+  expect_identical(render_numeric(rep(NA_real_, 3), what = "SD")[["SD"]], "")
+  expect_identical(render_numeric(c(0, 0, 0), what = "CV")[["CV"]], "")
+  expect_identical(render_numeric(c(-1, 2, 3), what = "GMean")[["GMean"]], "")
+
+  # Nothing available at all (no data) -> blank cell, not "NA [NA, NA]".
   allna <- render_numeric(rep(NA_real_, 3))
   expect_identical(allna[["Mean (SD)"]], "")
   expect_identical(allna[["Median [Min, Max]"]], "")
   expect_identical(allna[["Valid Obs."]], "0")
 
-  # Partially available -> the available parts still show.
+  # Composite with at least one value computed -> show it, NA the rest.
   expect_identical(
     render_numeric(c(1, 2, NA), what = "Median [Min, Max]")[["Median [Min, Max]"]],
     "1.50 [1.00, 2.00]"
+  )
+  expect_identical(
+    render_numeric(c(-1, 2, 3), what = "GMean (Mean)")[["GMean (Mean)"]],
+    "NA (1.33)"
   )
 })
 
@@ -123,44 +137,39 @@ test_that("Inf is a real value and survives rendering", {
 
 test_that("CV is unavailable when the mean is zero", {
   # sd/0 is Inf and 0/0 is NaN; these reached the table as "Inf%" and "NaN".
+  # Mean of each dataset is exactly 0, which renders "0" (not "0.00").
   expect_identical(
     render_numeric(c(-5, 5, -3, 3), what = "Mean (CV)")[["Mean (CV)"]],
-    "0.00 (-)"
+    "0 (NA)"
   )
   expect_identical(
     render_numeric(c(0, 0, 0), what = "Mean (CV)")[["Mean (CV)"]],
-    "0.00 (-)"
+    "0 (NA)"
   )
   # A non-zero mean still reports CV.
   expect_match(render_numeric(c(1, 2, 3), what = "CV")[["CV"]], "%$")
 })
 
-test_that("an explicit NA factor level counts as a category, not as missingness", {
-  # Promoting NA to a level (exclude = NULL / addNA) declares missingness to BE
-  # a category: is.na() on such a vector is all FALSE, so there is nothing left
-  # to exclude from the denominator. It is relabelled "Missing" for display but
-  # must still be counted, or the percentages sum past 100% and N < Nall while
-  # nothing is actually missing.
+test_that("render_cat mirrors base table() and never invents a 'Missing' level", {
+  # The ordinary factor: missing VALUES are dropped from the rows and from the
+  # PCTnoNA denominator, exactly like table(useNA = "no"). Missingness itself is
+  # reported separately by stat_tab, not by cat_stat.
+  g <- factor(c("a", "a", "b", NA, NA), levels = c("a", "b"))
+  expect_identical(names(render_cat(g)), names(table(g, useNA = "no")))
+  expect_identical(render_cat(g), c("a" = "2/3 (66.7%)", "b" = "1/3 (33.3%)"))
+  expect_identical(cat_stat(g)$a$N, 3L)
+
+  # A zero-count level is kept (table() keeps it); render_cat shows it blank.
+  h <- factor(c("a", "a", "b"), levels = c("a", "b", "c"))
+  expect_identical(names(render_cat(h)), names(table(h, useNA = "no")))
+  expect_identical(unname(render_cat(h)[["c"]]), "")
+
+  # An explicit NA *level* (factor(exclude = NULL)) is not a shape users are
+  # expected to create, but if it occurs render_cat still just mirrors table():
+  # the NA level is counted like any category and is NOT relabelled to
+  # "Missing" (which would collide with the genuine Missing row stat_tab adds).
   f <- factor(c("a", "a", "b", NA, NA), levels = c("a", "b", NA),
               exclude = NULL)
-  expect_identical(sum(is.na(f)), 0L)
-
-  expect_identical(
-    render_cat(f),
-    c("a" = "2/5 (40.0%)", "b" = "1/5 (20.0%)", "Missing" = "2/5 (40.0%)")
-  )
-  expect_identical(cat_stat(f)$a$N, 5L)
-  expect_identical(cat_stat(f)$a$Nall, 5L)
-
-  # A level whose LABEL is the string "NA" is an ordinary category: it is
-  # neither relabelled to "Missing" nor treated as missing. (Only a real NA
-  # level satisfies is.na(levels(.)); the string "NA" does not.)
-  s <- factor(c("a", "a", "b", "NA", "NA"))
-  expect_true("NA" %in% names(render_cat(s)))
-  expect_false("Missing" %in% names(render_cat(s)))
-  expect_identical(render_cat(s)[["NA"]], "2/5 (40.0%)")
-
-  # Genuinely missing values (no NA level) are excluded from PCTnoNA as before.
-  g <- factor(c("a", "a", "b", NA, NA), levels = c("a", "b"))
-  expect_identical(render_cat(g), c("a" = "2/3 (66.7%)", "b" = "1/3 (33.3%)"))
+  expect_identical(names(render_cat(f)), names(table(f, useNA = "no")))
+  expect_false("Missing" %in% names(render_cat(f)))
 })


### PR DESCRIPTION
This change includes some bugs that are already presented and potential bugs. More tests have been added to gate keep the output.

* `round_pad()` now rounds negative numbers away from zero. `round_pad(-0.135, 2)` returned `-0.13` instead of `-0.14`, systematically biasing signed values (e.g. change from baseline) toward zero.
* `select` filters now evaluate against the original values rather than value-label text. A filter such as `c(BMIBL = "RACEN != 1")` was silently ignored when `RACEN` was also being summarised, because it had been converted to a factor first.
* `select` filters that reference the `group` or `row_split` variable are now an error. Such a filter previously left the group columns unfiltered while still filtering the Total column, so Total reported a single group rather than the whole population. Grouping variables can only be used as `group` or `row_split`.
* `rbind()` of `cttab` objects with different `row_split` variables is now an error. It previously replaced every value in the combined table — including the well-formed part's — with a row count. Stack tables that share a row split, or format them separately.
* A `group` level named `"Total"` is now an error, as it collides with the generated Total column. Rename the level or pass `total = FALSE`.
* `select` filters are evaluated against the data columns and base functions only; they no longer see the user's workspace.
* `render_numeric()` no longer substitutes a statistic name inside a longer one that contains it — `"Mean (GMean)"` rendered as `"25.0 (G25.0)"`.
* A statistic that cannot be computed renders `NA` when it sits beside one that could (e.g. `Mean (SD)` for a single observation reads `"5.00 (NA)"`), and blank when nothing in the cell could be computed. Previously the two rendering paths disagreed — `"5.00 (NA)"` from one, `""` from the other — for the same input.
* `CV` is reported as unavailable when the mean is zero, instead of `"Inf%"` or `"NaN"`.
* `Inf` values are no longer silently dropped from rendered statistics.
* A categorical variable that is entirely missing now reports `Missing` instead of disappearing from the table.
* `cttab_plot()` evaluates all `select` filters before applying any, so the plot agrees with the table and no longer depends on the order of the names in `select`.
* `group_data()` no longer returns a `data.table` carrying a stale key describing the input's row order.
* `cttab_format()` refuses to render a table whose rows are not uniquely identified, rather than silently emitting row counts in place of statistics.
* `cttab_plot()` returns its list of plots invisibly.
* Documentation corrections: `cat_stat()` no longer claims zero-count levels are rendered (`render_cat()` blanks them), and `num_stat()` no longer documents `q25`/`q50`/`q75` aliases that do not exist.